### PR TITLE
sender: Fix senerio 2 and fix windowing issue

### DIFF
--- a/rdt22_sender.py
+++ b/rdt22_sender.py
@@ -60,7 +60,7 @@ class RDT22Sender:
             pkt = self.sndpkt[seq % constants.WINDOW_SIZE]
             self.udt_send(self.sock, pkt.to_bytes())
 
-    def input(self) -> bool:
+    def input(self, last_acks: bool) -> bool:
         """Called when a packet arrives from receiver"""
 
         if self.base == self.nextseqnum:
@@ -89,6 +89,12 @@ class RDT22Sender:
             else:
                 pass  # restart timer same as just waiting again
         else:  # corrupt ACK
+            # On the last set of transmitions even if ACK is corrupt, we slide the
+            # windows as there aren't later ACKs to correctly move the window
+            if last_acks:
+                self.base += 1
+                if self.base == self.nextseqnum:
+                    return True
             pass  # do nothing if corrupt
 
         return False

--- a/sender_app.py
+++ b/sender_app.py
@@ -101,13 +101,12 @@ def send_image(bytes_image: bytes, scenario: int, loss: float) -> float:
 
         # Sends all data packets
         while data_idx < len(data_packet_list):
-            sent = sender.rdt_send(data_packet_list[data_idx])
-            if sent:
+            while data_idx < len(data_packet_list) and sender.rdt_send(data_packet_list[data_idx]):
                 data_idx += 1
-            sender.input()
+            sender.input(False)
 
         # Ensure all packets are ACKed before finishing
-        while not sender.input():
+        while not sender.input(True):
             pass
 
         return start_time


### PR DESCRIPTION
If the sender recived a corrupted packet on the last packet of the file it would resend even thought the receiver though the transfer was complete. Assume corrupted packets on the last window increment the counter.

Windowing wasn't working properly because an if statement should have been a while loop to ensure that the window is always filled.